### PR TITLE
Added  MIT license and code of conduct page and markdown files for the same

### DIFF
--- a/build/CODE_OF_CONDUCT.md
+++ b/build/CODE_OF_CONDUCT.md
@@ -1,0 +1,89 @@
+
+# Contributor Covenant Code of Conduct
+
+
+
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+
+
+
+## Our Standards
+
+ Examples of behavior that contributes to a positive environment for our     community include:
+
+  •Demonstrating empathy and kindness toward other people 
+
+  •Being respectful of differing opinions, viewpoints, and experiences
+
+  •Giving and gracefully accepting constructive feedback
+
+  •Accepting responsibility and apologizing to those affected by our      mistakes, and learning from the experience
+
+  •Focusing on what is best not just for us as individuals, but for the overall community
+  
+Examples of unacceptable behavior include:
+
+•The use of sexualized language or imagery, and sexual attention or advances of any kind
+
+•Trolling, insulting or derogatory comments, and personal or political attacks
+
+•Public or private harassment
+
+•Publishing others’ private information, such as a physical or email address, without their explicit permission
+•Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+## Scope
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official email address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+
+## Enforcement
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at jagroopofficial29@gmail.com. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+## Enforcement Guidelines
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+1.  **Correction**
+
+#### Community Impact  :
+ Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+Consequence: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+2. **Warning**
+
+#### Community Impact: 
+A violation through a single incident or series of actions.
+
+#### Consequence:
+ A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+3. **Temporary Ban**
+
+#### Community Impact:
+ A serious violation of community standards, including sustained inappropriate behavior.
+
+#### Consequence: 
+A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+4. **Permanent Ban**
+  #### Community Impact: 
+Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+#### Consequence:
+ A permanent ban from any sort of public interaction within the community.
+## Attribution
+ This Code of Conduct is adapted from the Contributor Covenant, version 2.1, available at https://www.contributor-covenant.org/version/2/1/code_of_conduct.html. 
+
+ Community Impact Guidelines were inspired by [Mozilla’s code of conduct enforcement ladder](https://github.com/mozilla/inclusion).
+
+ For answers to common questions about this code of conduct, see the FAQ at https://www.contributor-covenant.org/faq. Translations are available at https://www.contributor-covenant.org/translations.

--- a/build/MIT_LICENSE.md
+++ b/build/MIT_LICENSE.md
@@ -1,0 +1,23 @@
+
+MIT License
+
+
+Copyright (c) 2022 JAGROOP
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/build/codeofconduct.html
+++ b/build/codeofconduct.html
@@ -1,0 +1,191 @@
+<!DOCTYPE html>
+<html lang="en" class="sm:scroll-smooth">
+    <head>
+        <meta charset="UTF-8" />
+        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <style>
+            body{
+                background-color: #c7d685;
+                min-height: 100vh;
+                display: absolute;
+                flex-direction: column;
+                padding: 50px;
+            }
+            
+            .outer-container{
+            margin-top: auto;
+            background-color:rgb(5, 143, 113);
+            height: 100 vh;
+             width: 100 vw;
+             border-radius: 1rem;
+             
+             position: relative;
+            }
+           .btn {
+                color:#1a1717;
+                text-decoration: none;
+                padding: 0.5rem;
+                border: 1px solid #333333;
+                background-color: #eaeef0;
+                border-radius: 10px;
+
+            }
+            .inner-box{
+                padding:80px;
+                position: relative;
+                color: #191a18;
+                background-color: #fff;
+                text-align: left;
+            }
+            h1{
+                text-align: center;
+                color:#143fc2;
+            }
+            a {
+                display: inline-block;
+                transition: .3s;
+                font-weight:bold;
+                text-decoration:none;
+                color:#437df8;
+                align-items: right;
+                }
+                a:hover {
+                -webkit-transform: scale(1.2);
+                transform: scale(1.2);
+                opacity: 0.9;
+                color: #1408b1;
+                }
+                footer{
+                margin-top: auto;
+                text-align: right;
+                
+            }
+
+            @media (max-width: 600px) {
+                
+                .outer-container{
+                    display:grid;
+                    flex-direction: column;
+
+                }
+                
+               
+
+              }
+
+            
+            
+
+        </style>
+        <title> Code Of Conduct</title>
+     </head>
+     <body>
+        <div class="outer-container">
+            <h1  style=color:#fff;justify-content:center;> Code of Conduct</h1>
+            <div class="inner-box">
+            <p>
+
+              <h1>Our Pledge</h1> 
+
+                 We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+                 We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+                 <hr>
+
+
+
+              <h1> Our Standards</h1>
+
+               Examples of behavior that contributes to a positive environment for our community include:<br/>
+
+               •Demonstrating empathy and kindness toward other people <br/>
+
+              •Being respectful of differing opinions, viewpoints, and experiences<br/>
+
+              •Giving and gracefully accepting constructive feedback<br/>
+
+              •Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience<br/>
+
+             •Focusing on what is best not just for us as individuals, but for the overall community<br/>
+  
+             •Examples of unacceptable behavior include:<br/>
+
+            •The use of sexualized language or imagery, and sexual attention or advances of any kind<br/>
+
+            •Trolling, insulting or derogatory comments, and personal or political attacks<br/>
+
+            •Public or private harassment<br/>
+
+            •Publishing others’ private information, such as a physical or email address, without their explicit permission
+            •Other conduct which could reasonably be considered inappropriate in a professional setting.
+
+             <hr>
+
+           <h1>Enforcement Responsibilities</h1> 
+            Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+            Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+           <hr>
+
+           <h1>Scope</h1> 
+            This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official email address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+            <hr>
+
+
+            <h1>Enforcement</h1> 
+            Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at <a href="jagroopofficial29@gmail.com">jagroopofficial29@gmail.com</a>. All complaints will be reviewed and investigated promptly and fairly.
+
+            All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+            <hr>
+
+            <h1>Enforcement Guidelines</h1> 
+            Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+                <h2>1.Correction</h2>
+
+                        <h4> Community Impact:</h4>
+                             Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+                        <h4>Consequence:</h4>
+                         A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+                <h2>2.Warning</h2>
+
+                         <h4> Community Impact</h4>
+                          A violation through a single incident or series of actions.
+
+                        <h4> Consequence:</h4>
+                          A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+                <h2>3.Temporary Ban</h2>
+
+                        <h4>Community Impact:</h4>
+                         A serious violation of community standards, including sustained inappropriate behavior.
+
+                        <h4>Consequence: </h4>
+                         A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+                <h2>4.Permanent Ban</h2>
+                         <h4>Community Impact:</h4> 
+                         Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+                        <h4> Consequence:</h4>
+                         A permanent ban from any sort of public interaction within the community.
+                         <hr>
+            <h1>Attribution</h1>
+            This Code of Conduct is adapted from the Contributor Covenant, version 2.1, available at <a href ="https://www.contributor-covenant.org/version/2/1/code_of_conduct.html">https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.</a>. <br/>
+
+             <p>Community Impact Guidelines were inspired by <a href ="https://github.com/mozilla/inclusion">Mozilla’s code of conduct enforcement ladder</a>]</p>
+
+             For answers to common questions about this code of conduct, see the FAQ at <a href="https://www.contributor-covenant.org/faq"> https://www.contributor-covenant.org/faq</a>. Translations are available at <a href=" https://www.contributor-covenant.org/translations">https://www.contributor-covenant.org/translations</a>
+
+        </p>
+              
+
+        </div>
+    </div>
+        <hr>
+        <footer><a class="btn" href=index.html>Back to main page</a></footer>
+
+     </body> 
+     </html> 

--- a/build/index.html
+++ b/build/index.html
@@ -14,6 +14,8 @@
   <title>Acme Rockets</title>
   <link rel="shortcut icon" href="../favicon.ico" type="image/x-icon" />
   <link rel="stylesheet" href="css/style.css" />
+  <link rel="mitlicense" href="mitLicense.html">
+  <link rel="codeofconduct" href="./codeofconduct.html">
   <script src="js/main.js" defer></script>
 </head>
 
@@ -221,6 +223,10 @@
       <div class="flex flex-col sm:gap-2">
         <p class="text-right">Copyright &copy; <span id="year">2022</span></p>
         <p class="text-right">All Rights Reserved</p>
+        <p class="text-right">  <a href="./mitLicense.html">MIT License</a></p>
+        <p class="text-right"> <a href="./codeofconduct.html">Code Of Conduct</a></p>
+
+
       </div>
     </section>
   </footer>
@@ -244,3 +250,4 @@
 </body>
 
 </html>
+

--- a/build/mitLicense.html
+++ b/build/mitLicense.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html lang="en" class="sm:scroll-smooth">
+    <head>
+        <meta charset="UTF-8" />
+        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <style>
+        body{
+                background-color: #fff;
+        }
+        .outer-box{ 
+         width: 650px;
+         height: 600px;
+         font-family: sans-serif;
+         background-color:rgb(4, 118, 94);
+         color: #fff;
+         padding: 10px;
+         margin: 50px 80px 80px 300px;
+         border-radius: 4px;
+         }
+        .text{
+          text-align: justify;
+          text-justify: inter-word;
+          display:absolute;
+          background-color: lineargradient(#fff,135deg,blue);
+        }
+        a {
+            display: inline-block;
+            transition: .3s;
+            font-weight:bold;
+            text-decoration:none;
+            color:#0b0101;
+            
+            }
+            a:hover {
+            -webkit-transform: scale(1.2);
+            transform: scale(1.2);
+            opacity: 0.9;
+            color: #b6d919;
+            
+            
+            }
+            footer{
+                margin-top: auto;
+                text-align: right;
+                
+            }
+
+        @media (max-width: 800px) {
+            .outer-box{
+              width: 500px;
+             height: 400px;
+             display: flex;
+             padding:2px;
+             margin:5px;
+             Display:flex; 
+             Align-items: center
+
+            }
+
+        }
+
+        </style>
+        <title>MIT License</title>  
+    </head> 
+    <body>
+        <div class="outer-box">
+        <div class="text">
+            <p><h1 style=color:#fff;text-align:center> MIT License</h1>
+                <p>Copyright (c) 2022 JAGROOP</p><br />
+
+               Permission is hereby granted, free of charge, to any person obtaining a copy
+               of this software and associated documentation files (the "Software"), to deal
+               in the Software without restriction, including without limitation the rights
+               to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+               copies of the Software, and to permit persons to whom the Software is
+               furnished to do so, subject to the following conditions:
+
+              The above copyright notice and this permission notice shall be included in all
+              copies or substantial portions of the Software.
+
+              THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+              IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+              FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+              AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+              LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+              OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+              SOFTWARE.
+
+
+
+
+            </p>
+            <footer><a href="./index.html">Back</a></footer>
+          
+        </div>
+    </div>  
+    </body>   
+
+</html>


### PR DESCRIPTION
1.Added markdown files for MIT license and code of conduct 
2.Added  responsive webpage for MIT License using HTML5 and CSS Subsequently, added a link to go back to main page for good user-experience 
3. Added responsive webpage for code of conduct for this project using HTML5 & CSS . Subsequently, added a link to go back to main page for good user-experience 
<img width="959" alt="image" src="https://github.com/Jagroop2001/AcmeRockets/assets/134845162/07fee2cf-d59b-41a6-b3a9-9b122dca18e0">
<img width="959" alt="image" src="https://github.com/Jagroop2001/AcmeRockets/assets/134845162/c677c67b-966c-41e2-bed1-c0aee972ec8e">
<img width="473" alt="image" src="https://github.com/Jagroop2001/AcmeRockets/assets/134845162/47a90c61-40a7-4f6f-8d30-ebbfc535b369">
<img width="548" alt="image" src="https://github.com/Jagroop2001/AcmeRockets/assets/134845162/cb9f3064-2964-483c-bca3-8b5994e5b2c0">
<img width="539" alt="image" src="https://github.com/Jagroop2001/AcmeRockets/assets/134845162/71d25f25-15ad-4501-9cb8-463be432d1ed">

